### PR TITLE
Change image URL for surveillance article

### DIFF
--- a/clown-network/chronicles/index.html
+++ b/clown-network/chronicles/index.html
@@ -735,7 +735,7 @@
             description: "Why surveillance technology alone cannot guarantee safety—and what accountable public institutions must do to protect communities and small businesses effectively.",
             url: "https://kristinap09.github.io/clown-network/chronicles/Life_in_a_City_Where_Cameras_Watch_but_No_One_Acts.html",
             date: "2026-01-11",
-            imageUrl: "https://kristinap09.github.io/assets/images/smart-city-surveillance.jpg",
+            imageUrl: "https://raw.githubusercontent.com/KristinaP09/kristinap09.github.io/refs/heads/KristinaP09-patch-496440/assets/images/smart-city-surveillance.png",
             tags: ["Public Safety", "Surveillance", "Accountability", "Community Protection", "Small Businesses"]
             },
             {title: "Systems, Truth, and the Mathematics of Dysfunction",


### PR DESCRIPTION
Updated image URL for the surveillance article to point to a new source.